### PR TITLE
Updates for Karpenter 0.34.x using v1beta1 APIs

### DIFF
--- a/karpenter.k8s.aws/ec2nodeclass_v1beta1.json
+++ b/karpenter.k8s.aws/ec2nodeclass_v1beta1.json
@@ -2,18 +2,18 @@
   "description": "EC2NodeClass is the Schema for the EC2NodeClass API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider. This will contain configuration necessary to launch instances in AWS.",
+      "description": "EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.\nThis will contain configuration necessary to launch instances in AWS.",
       "properties": {
         "amiFamily": {
           "description": "AMIFamily is the AMI family that instances use.",
@@ -30,7 +30,7 @@
         "amiSelectorTerms": {
           "description": "AMISelectorTerms is a list of or ami selector terms. The terms are ORed.",
           "items": {
-            "description": "AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes. If multiple fields are used for selection, the requirements are ANDed.",
+            "description": "AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.\nIf multiple fields are used for selection, the requirements are ANDed.",
             "properties": {
               "id": {
                 "description": "ID is the ami id in EC2",
@@ -38,18 +38,18 @@
                 "type": "string"
               },
               "name": {
-                "description": "Name is the ami name in EC2. This value is the name field, which is different from the name tag.",
+                "description": "Name is the ami name in EC2.\nThis value is the name field, which is different from the name tag.",
                 "type": "string"
               },
               "owner": {
-                "description": "Owner is the owner for the ami. You can specify a combination of AWS account IDs, \"self\", \"amazon\", and \"aws-marketplace\"",
+                "description": "Owner is the owner for the ami.\nYou can specify a combination of AWS account IDs, \"self\", \"amazon\", and \"aws-marketplace\"",
                 "type": "string"
               },
               "tags": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Tags is a map of key/value tags used to select subnets Specifying '*' for a value selects all values for a given tag key.",
+                "description": "Tags is a map of key/value tags used to select subnets\nSpecifying '*' for a value selects all values for a given tag key.",
                 "maxProperties": 20,
                 "type": "object",
                 "x-kubernetes-validations": [
@@ -96,11 +96,11 @@
                     "type": "boolean"
                   },
                   "encrypted": {
-                    "description": "Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only be attached to instances that support Amazon EBS encryption. If you are creating a volume from a snapshot, you can't specify an encryption value.",
+                    "description": "Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only\nbe attached to instances that support Amazon EBS encryption. If you are creating\na volume from a snapshot, you can't specify an encryption value.",
                     "type": "boolean"
                   },
                   "iops": {
-                    "description": "IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes, this represents the number of IOPS that are provisioned for the volume. For gp2 volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. \n The following are the supported values for each volume type: \n * gp3: 3,000-16,000 IOPS \n * io1: 100-64,000 IOPS \n * io2: 100-64,000 IOPS \n For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances). Other instance families guarantee performance up to 32,000 IOPS. \n This parameter is supported for io1, io2, and gp3 volumes only. This parameter is not supported for gp2, st1, sc1, or standard volumes.",
+                    "description": "IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,\nthis represents the number of IOPS that are provisioned for the volume. For\ngp2 volumes, this represents the baseline performance of the volume and the\nrate at which the volume accumulates I/O credits for bursting.\n\n\nThe following are the supported values for each volume type:\n\n\n   * gp3: 3,000-16,000 IOPS\n\n\n   * io1: 100-64,000 IOPS\n\n\n   * io2: 100-64,000 IOPS\n\n\nFor io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built\non the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).\nOther instance families guarantee performance up to 32,000 IOPS.\n\n\nThis parameter is supported for io1, io2, and gp3 volumes only. This parameter\nis not supported for gp2, st1, sc1, or standard volumes.",
                     "format": "int64",
                     "type": "integer"
                   },
@@ -113,7 +113,7 @@
                     "type": "string"
                   },
                   "throughput": {
-                    "description": "Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s. Valid Range: Minimum value of 125. Maximum value of 1000.",
+                    "description": "Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.\nValid Range: Minimum value of 125. Maximum value of 1000.",
                     "format": "int64",
                     "type": "integer"
                   },
@@ -134,11 +134,11 @@
                         "type": "string"
                       }
                     ],
-                    "description": "VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or a volume size. The following are the supported volumes sizes for each volume type: \n * gp2 and gp3: 1-16,384 \n * io1 and io2: 4-16,384 \n * st1 and sc1: 125-16,384 \n * standard: 1-1,024",
+                    "description": "VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or\na volume size. The following are the supported volumes sizes for each volume\ntype:\n\n\n   * gp2 and gp3: 1-16,384\n\n\n   * io1 and io2: 4-16,384\n\n\n   * st1 and sc1: 125-16,384\n\n\n   * standard: 1-1,024",
                     "x-kubernetes-int-or-string": true
                   },
                   "volumeType": {
-                    "description": "VolumeType of the block device. For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide.",
+                    "description": "VolumeType of the block device.\nFor more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)\nin the Amazon Elastic Compute Cloud User Guide.",
                     "enum": [
                       "standard",
                       "io1",
@@ -161,7 +161,7 @@
                 "additionalProperties": false
               },
               "rootVolume": {
-                "description": "RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can configure at most one root volume in BlockDeviceMappings.",
+                "description": "RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can\nconfigure at most one root volume in BlockDeviceMappings.",
                 "type": "boolean"
               }
             },
@@ -178,12 +178,29 @@
           ]
         },
         "context": {
-          "description": "Context is a Reserved field in EC2 APIs https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html",
+          "description": "Context is a Reserved field in EC2 APIs\nhttps://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html",
           "type": "string"
         },
         "detailedMonitoring": {
           "description": "DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched",
           "type": "boolean"
+        },
+        "instanceProfile": {
+          "description": "InstanceProfile is the AWS entity that instances use.\nThis field is mutually exclusive from role.\nThe instance profile should already have a role assigned to it that Karpenter\n has PassRole permission on for instance launch using this instanceProfile to succeed.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "instanceProfile cannot be empty",
+              "rule": "self != ''"
+            }
+          ]
+        },
+        "instanceStorePolicy": {
+          "description": "InstanceStorePolicy specifies how to handle instance-store disks.",
+          "enum": [
+            "RAID0"
+          ],
+          "type": "string"
         },
         "metadataOptions": {
           "default": {
@@ -192,11 +209,11 @@
             "httpPutResponseHopLimit": 2,
             "httpTokens": "required"
           },
-          "description": "MetadataOptions for the generated launch template of provisioned nodes. \n This specifies the exposure of the Instance Metadata Service to provisioned EC2 nodes. For more information, see Instance Metadata and User Data (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) in the Amazon Elastic Compute Cloud User Guide. \n Refer to recommended, security best practices (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node) for limiting exposure of Instance Metadata and User Data to pods. If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6 disabled, with httpPutResponseLimit of 2, and with httpTokens required.",
+          "description": "MetadataOptions for the generated launch template of provisioned nodes.\n\n\nThis specifies the exposure of the Instance Metadata Service to\nprovisioned EC2 nodes. For more information,\nsee Instance Metadata and User Data (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)\nin the Amazon Elastic Compute Cloud User Guide.\n\n\nRefer to recommended, security best practices\n(https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)\nfor limiting exposure of Instance Metadata and User Data to pods.\nIf omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6\ndisabled, with httpPutResponseLimit of 2, and with httpTokens\nrequired.",
           "properties": {
             "httpEndpoint": {
               "default": "enabled",
-              "description": "HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned nodes. If metadata options is non-nil, but this parameter is not specified, the default state is \"enabled\". \n If you specify a value of \"disabled\", instance metadata will not be accessible on the node.",
+              "description": "HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned\nnodes. If metadata options is non-nil, but this parameter is not specified,\nthe default state is \"enabled\".\n\n\nIf you specify a value of \"disabled\", instance metadata will not be accessible\non the node.",
               "enum": [
                 "enabled",
                 "disabled"
@@ -205,7 +222,7 @@
             },
             "httpProtocolIPv6": {
               "default": "disabled",
-              "description": "HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata service on provisioned nodes. If metadata options is non-nil, but this parameter is not specified, the default state is \"disabled\".",
+              "description": "HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata\nservice on provisioned nodes. If metadata options is non-nil, but this parameter\nis not specified, the default state is \"disabled\".",
               "enum": [
                 "enabled",
                 "disabled"
@@ -214,7 +231,7 @@
             },
             "httpPutResponseHopLimit": {
               "default": 2,
-              "description": "HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Possible values are integers from 1 to 64. If metadata options is non-nil, but this parameter is not specified, the default value is 2.",
+              "description": "HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for\ninstance metadata requests. The larger the number, the further instance\nmetadata requests can travel. Possible values are integers from 1 to 64.\nIf metadata options is non-nil, but this parameter is not specified, the\ndefault value is 2.",
               "format": "int64",
               "maximum": 64,
               "minimum": 1,
@@ -222,7 +239,7 @@
             },
             "httpTokens": {
               "default": "required",
-              "description": "HTTPTokens determines the state of token usage for instance metadata requests. If metadata options is non-nil, but this parameter is not specified, the default state is \"required\". \n If the state is optional, one can choose to retrieve instance metadata with or without a signed token header on the request. If one retrieves the IAM role credentials without a token, the version 1.0 role credentials are returned. If one retrieves the IAM role credentials using a valid signed token, the version 2.0 role credentials are returned. \n If the state is \"required\", one must send a signed token header with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available.",
+              "description": "HTTPTokens determines the state of token usage for instance metadata\nrequests. If metadata options is non-nil, but this parameter is not\nspecified, the default state is \"required\".\n\n\nIf the state is optional, one can choose to retrieve instance metadata with\nor without a signed token header on the request. If one retrieves the IAM\nrole credentials without a token, the version 1.0 role credentials are\nreturned. If one retrieves the IAM role credentials using a valid signed\ntoken, the version 2.0 role credentials are returned.\n\n\nIf the state is \"required\", one must send a signed token header with any\ninstance metadata retrieval requests. In this state, retrieving the IAM\nrole credentials always returns the version 2.0 credentials; the version\n1.0 credentials are not available.",
               "enum": [
                 "required",
                 "optional"
@@ -234,7 +251,7 @@
           "additionalProperties": false
         },
         "role": {
-          "description": "Role is the AWS identity that nodes use. This field is immutable. Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances. This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented for the old instance profiles on an update.",
+          "description": "Role is the AWS identity that nodes use. This field is immutable.\nThis field is mutally exclusive from instanceProfile.\nMarking this field as immutable avoids concerns around terminating managed instance profiles from running instances.\nThis field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented\nfor the old instance profiles on an update.",
           "type": "string",
           "x-kubernetes-validations": [
             {
@@ -250,7 +267,7 @@
         "securityGroupSelectorTerms": {
           "description": "SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.",
           "items": {
-            "description": "SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes. If multiple fields are used for selection, the requirements are ANDed.",
+            "description": "SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.\nIf multiple fields are used for selection, the requirements are ANDed.",
             "properties": {
               "id": {
                 "description": "ID is the security group id in EC2",
@@ -258,14 +275,14 @@
                 "type": "string"
               },
               "name": {
-                "description": "Name is the security group name in EC2. This value is the name field, which is different from the name tag.",
+                "description": "Name is the security group name in EC2.\nThis value is the name field, which is different from the name tag.",
                 "type": "string"
               },
               "tags": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Tags is a map of key/value tags used to select subnets Specifying '*' for a value selects all values for a given tag key.",
+                "description": "Tags is a map of key/value tags used to select subnets\nSpecifying '*' for a value selects all values for a given tag key.",
                 "maxProperties": 20,
                 "type": "object",
                 "x-kubernetes-validations": [
@@ -303,7 +320,7 @@
         "subnetSelectorTerms": {
           "description": "SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.",
           "items": {
-            "description": "SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes. If multiple fields are used for selection, the requirements are ANDed.",
+            "description": "SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.\nIf multiple fields are used for selection, the requirements are ANDed.",
             "properties": {
               "id": {
                 "description": "ID is the subnet id in EC2",
@@ -314,7 +331,7 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Tags is a map of key/value tags used to select subnets Specifying '*' for a value selects all values for a given tag key.",
+                "description": "Tags is a map of key/value tags used to select subnets\nSpecifying '*' for a value selects all values for a given tag key.",
                 "maxProperties": 20,
                 "type": "object",
                 "x-kubernetes-validations": [
@@ -375,7 +392,7 @@
           ]
         },
         "userData": {
-          "description": "UserData to be applied to the provisioned nodes. It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into this UserData to ensure nodes are being provisioned with the correct configuration.",
+          "description": "UserData to be applied to the provisioned nodes.\nIt must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into\nthis UserData to ensure nodes are being provisioned with the correct configuration.",
           "type": "string"
         }
       },
@@ -398,7 +415,7 @@
       "description": "EC2NodeClassStatus contains the resolved state of the EC2NodeClass",
       "properties": {
         "amis": {
-          "description": "AMI contains the current AMI values that are available to the cluster under the AMI selectors.",
+          "description": "AMI contains the current AMI values that are available to the\ncluster under the AMI selectors.",
           "items": {
             "description": "AMI contains resolved AMI selector values utilized for node launch",
             "properties": {
@@ -413,18 +430,18 @@
               "requirements": {
                 "description": "Requirements of the AMI to be utilized on an instance type",
                 "items": {
-                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                   "properties": {
                     "key": {
                       "description": "The label key that the selector applies to.",
                       "type": "string"
                     },
                     "operator": {
-                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                       "type": "string"
                     },
                     "values": {
-                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                       "items": {
                         "type": "string"
                       },
@@ -455,7 +472,7 @@
           "type": "string"
         },
         "securityGroups": {
-          "description": "SecurityGroups contains the current Security Groups values that are available to the cluster under the SecurityGroups selectors.",
+          "description": "SecurityGroups contains the current Security Groups values that are available to the\ncluster under the SecurityGroups selectors.",
           "items": {
             "description": "SecurityGroup contains resolved SecurityGroup selector values utilized for node launch",
             "properties": {
@@ -477,7 +494,7 @@
           "type": "array"
         },
         "subnets": {
-          "description": "Subnets contains the current Subnet values that are available to the cluster under the subnet selectors.",
+          "description": "Subnets contains the current Subnet values that are available to the\ncluster under the subnet selectors.",
           "items": {
             "description": "Subnet contains resolved Subnet selector values utilized for node launch",
             "properties": {

--- a/karpenter.sh/nodeclaim_v1beta1.json
+++ b/karpenter.sh/nodeclaim_v1beta1.json
@@ -206,11 +206,11 @@
                 "x-kubernetes-validations": [
                   {
                     "message": "label domain \"kubernetes.io\" is restricted",
-                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.find(\"^([^/]+)\").endsWith(\"node.kubernetes.io/\") || self.find(\"^([^/]+)\").endsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
+                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.startsWith(\"node.kubernetes.io/\") || self.startsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
                   },
                   {
                     "message": "label domain \"k8s.io\" is restricted",
-                    "rule": "self.find(\"^([^/]+)\").endsWith(\"kops.k8s.io\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
+                    "rule": "self.startsWith(\"kops.k8s.io/\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
                   },
                   {
                     "message": "label domain \"karpenter.sh\" is restricted",

--- a/karpenter.sh/nodeclaim_v1beta1.json
+++ b/karpenter.sh/nodeclaim_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "NodeClaim is the Schema for the NodeClaims API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,10 +16,10 @@
       "description": "NodeClaimSpec describes the desired state of the NodeClaim",
       "properties": {
         "kubelet": {
-          "description": "Kubelet defines args to be used when configuring kubelet on provisioned nodes. They are a subset of the upstream types, recognizing not all options may be supported. Wherever possible, the types and names should reflect the upstream kubelet types.",
+          "description": "Kubelet defines args to be used when configuring kubelet on provisioned nodes.\nThey are a subset of the upstream types, recognizing not all options may be supported.\nWherever possible, the types and names should reflect the upstream kubelet types.",
           "properties": {
             "clusterDNS": {
-              "description": "clusterDNS is a list of IP addresses for the cluster DNS server. Note that not all providers may use all addresses.",
+              "description": "clusterDNS is a list of IP addresses for the cluster DNS server.\nNote that not all providers may use all addresses.",
               "items": {
                 "type": "string"
               },
@@ -44,7 +44,7 @@
               ]
             },
             "evictionMaxPodGracePeriod": {
-              "description": "EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in response to soft eviction thresholds being met.",
+              "description": "EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in\nresponse to soft eviction thresholds being met.",
               "format": "int32",
               "type": "integer"
             },
@@ -76,14 +76,14 @@
               ]
             },
             "imageGCHighThresholdPercent": {
-              "description": "ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive. When specified, the value must be greater than ImageGCLowThresholdPercent.",
+              "description": "ImageGCHighThresholdPercent is the percent of disk usage after which image\ngarbage collection is always run. The percent is calculated by dividing this\nfield value by 100, so this field must be between 0 and 100, inclusive.\nWhen specified, the value must be greater than ImageGCLowThresholdPercent.",
               "format": "int32",
               "maximum": 100,
               "minimum": 0,
               "type": "integer"
             },
             "imageGCLowThresholdPercent": {
-              "description": "ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the field value must be between 0 and 100, inclusive. When specified, the value must be less than imageGCHighThresholdPercent",
+              "description": "ImageGCLowThresholdPercent is the percent of disk usage before which image\ngarbage collection is never run. Lowest disk usage to garbage collect to.\nThe percent is calculated by dividing this field value by 100,\nso the field value must be between 0 and 100, inclusive.\nWhen specified, the value must be less than imageGCHighThresholdPercent",
               "format": "int32",
               "maximum": 100,
               "minimum": 0,
@@ -116,13 +116,13 @@
               ]
             },
             "maxPods": {
-              "description": "MaxPods is an override for the maximum number of pods that can run on a worker node instance.",
+              "description": "MaxPods is an override for the maximum number of pods that can run on\na worker node instance.",
               "format": "int32",
               "minimum": 0,
               "type": "integer"
             },
             "podsPerCore": {
-              "description": "PodsPerCore is an override for the number of pods that can run on a worker node instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if MaxPods is a lower value, that value will be used.",
+              "description": "PodsPerCore is an override for the number of pods that can run on a worker node\ninstance based on the number of cpu cores. This value cannot exceed MaxPods, so, if\nMaxPods is a lower value, that value will be used.",
               "format": "int32",
               "minimum": 0,
               "type": "integer"
@@ -196,7 +196,7 @@
         "requirements": {
           "description": "Requirements are layered with GetLabels and applied to every node.",
           "items": {
-            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
             "properties": {
               "key": {
                 "description": "The label key that the selector applies to.",
@@ -206,11 +206,11 @@
                 "x-kubernetes-validations": [
                   {
                     "message": "label domain \"kubernetes.io\" is restricted",
-                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.startsWith(\"node.kubernetes.io/\") || self.startsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
+                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.find(\"^([^/]+)\").endsWith(\"node.kubernetes.io/\") || self.find(\"^([^/]+)\").endsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
                   },
                   {
                     "message": "label domain \"k8s.io\" is restricted",
-                    "rule": "self.startsWith(\"kops.k8s.io/\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
+                    "rule": "self.find(\"^([^/]+)\").endsWith(\"kops.k8s.io\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
                   },
                   {
                     "message": "label domain \"karpenter.sh\" is restricted",
@@ -227,7 +227,7 @@
                 ]
               },
               "operator": {
-                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                 "enum": [
                   "In",
                   "NotIn",
@@ -239,7 +239,7 @@
                 "type": "string"
               },
               "values": {
-                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                 "items": {
                   "type": "string"
                 },
@@ -292,12 +292,12 @@
           "additionalProperties": false
         },
         "startupTaints": {
-          "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
+          "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
           "items": {
-            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+            "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
             "properties": {
               "effect": {
-                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                "description": "Required. The effect of the taint on pods\nthat do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute.",
                 "enum": [
                   "NoSchedule",
                   "PreferNoSchedule",
@@ -312,7 +312,7 @@
                 "type": "string"
               },
               "timeAdded": {
-                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                "description": "TimeAdded represents the time at which the taint was added.\nIt is only written for NoExecute taints.",
                 "format": "date-time",
                 "type": "string"
               },
@@ -334,10 +334,10 @@
         "taints": {
           "description": "Taints will be applied to the NodeClaim's node.",
           "items": {
-            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+            "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
             "properties": {
               "effect": {
-                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                "description": "Required. The effect of the taint on pods\nthat do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute.",
                 "enum": [
                   "NoSchedule",
                   "PreferNoSchedule",
@@ -352,7 +352,7 @@
                 "type": "string"
               },
               "timeAdded": {
-                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                "description": "TimeAdded represents the time at which the taint was added.\nIt is only written for NoExecute taints.",
                 "format": "date-time",
                 "type": "string"
               },
@@ -417,10 +417,10 @@
         "conditions": {
           "description": "Conditions contains signals for health and readiness",
           "items": {
-            "description": "Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
             "properties": {
               "lastTransitionTime": {
-                "description": "LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).",
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
                 "type": "string"
               },
               "message": {
@@ -432,7 +432,7 @@
                 "type": "string"
               },
               "severity": {
-                "description": "Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.",
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
                 "type": "string"
               },
               "status": {

--- a/karpenter.sh/nodepool_v1beta1.json
+++ b/karpenter.sh/nodepool_v1beta1.json
@@ -13,7 +13,7 @@
       "type": "object"
     },
     "spec": {
-      "description": "NodePoolSpec is the top level provisioner specification. Provisioners launch nodes in response to pods that are unschedulable. A single provisioner is capable of managing a diverse set of nodes. Node properties are determined from a combination of provisioner and pod scheduling constraints.",
+      "description": "NodePoolSpec is the top level nodepool specification. Nodepools launch nodes in response to pods that are unschedulable. A single nodepool is capable of managing a diverse set of nodes. Node properties are determined from a combination of nodepool and pod scheduling constraints.",
       "properties": {
         "disruption": {
           "default": {
@@ -500,7 +500,7 @@
           "additionalProperties": false
         },
         "weight": {
-          "description": "Weight is the priority given to the provisioner during scheduling. A higher numerical weight indicates that this provisioner will be ordered ahead of other provisioners with lower weights. A provisioner with no weight will be treated as if it is a provisioner with a weight of 0.",
+          "description": "Weight is the priority given to the nodepool during scheduling. A higher numerical weight indicates that this nodepool will be ordered ahead of other nodepools with lower weights. A nodepool with no weight will be treated as if it is a nodepool with a weight of 0.",
           "format": "int32",
           "maximum": 100,
           "minimum": 1,

--- a/karpenter.sh/nodepool_v1beta1.json
+++ b/karpenter.sh/nodepool_v1beta1.json
@@ -2,18 +2,18 @@
   "description": "NodePool is the Schema for the NodePools API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "NodePoolSpec is the top level nodepool specification. Nodepools launch nodes in response to pods that are unschedulable. A single nodepool is capable of managing a diverse set of nodes. Node properties are determined from a combination of nodepool and pod scheduling constraints.",
+      "description": "NodePoolSpec is the top level nodepool specification. Nodepools\nlaunch nodes in response to pods that are unschedulable. A single nodepool\nis capable of managing a diverse set of nodes. Node properties are determined\nfrom a combination of nodepool and pod scheduling constraints.",
       "properties": {
         "disruption": {
           "default": {
@@ -22,14 +22,55 @@
           },
           "description": "Disruption contains the parameters that relate to Karpenter's disruption logic",
           "properties": {
+            "budgets": {
+              "default": [
+                {
+                  "nodes": "10%"
+                }
+              ],
+              "description": "Budgets is a list of Budgets.\nIf there are multiple active budgets, Karpenter uses\nthe most restrictive value. If left undefined,\nthis will default to one budget with a value to 10%.",
+              "items": {
+                "description": "Budget defines when Karpenter will restrict the\nnumber of Node Claims that can be terminating simultaneously.",
+                "properties": {
+                  "duration": {
+                    "description": "Duration determines how long a Budget is active since each Schedule hit.\nOnly minutes and hours are accepted, as cron does not work in seconds.\nIf omitted, the budget is always active.\nThis is required if Schedule is set.\nThis regex has an optional 0s at the end since the duration.String() always adds\na 0s at the end.",
+                    "pattern": "^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$",
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "default": "10%",
+                    "description": "Nodes dictates the maximum number of NodeClaims owned by this NodePool\nthat can be terminating at once. This is calculated by counting nodes that\nhave a deletion timestamp set, or are actively being deleted by Karpenter.\nThis field is required when specifying a budget.\nThis cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern\nchecking for int nodes for IntOrString nodes.\nRef: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388",
+                    "pattern": "^((100|[0-9]{1,2})%|[0-9]+)$",
+                    "type": "string"
+                  },
+                  "schedule": {
+                    "description": "Schedule specifies when a budget begins being active, following\nthe upstream cronjob syntax. If omitted, the budget is always active.\nTimezones are not supported.\nThis field is required if Duration is set.",
+                    "pattern": "^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\\s(.+)\\s(.+)\\s(.+)\\s(.+))$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "nodes"
+                ],
+                "type": "object"
+              },
+              "maxItems": 50,
+              "type": "array",
+              "x-kubernetes-validations": [
+                {
+                  "message": "'schedule' must be set with 'duration'",
+                  "rule": "self.all(x, has(x.schedule) == has(x.duration))"
+                }
+              ]
+            },
             "consolidateAfter": {
-              "description": "ConsolidateAfter is the duration the controller will wait before attempting to terminate nodes that are underutilized. Refer to ConsolidationPolicy for how underutilization is considered.",
+              "description": "ConsolidateAfter is the duration the controller will wait\nbefore attempting to terminate nodes that are underutilized.\nRefer to ConsolidationPolicy for how underutilization is considered.",
               "pattern": "^(([0-9]+(s|m|h))+)|(Never)$",
               "type": "string"
             },
             "consolidationPolicy": {
               "default": "WhenUnderutilized",
-              "description": "ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation algorithm. This policy defaults to \"WhenUnderutilized\" if not specified",
+              "description": "ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation\nalgorithm. This policy defaults to \"WhenUnderutilized\" if not specified",
               "enum": [
                 "WhenEmpty",
                 "WhenUnderutilized"
@@ -38,7 +79,7 @@
             },
             "expireAfter": {
               "default": "720h",
-              "description": "ExpireAfter is the duration the controller will wait before terminating a node, measured from when the node is created. This is useful to implement features like eventually consistent node upgrade, memory leak protection, and disruption testing.",
+              "description": "ExpireAfter is the duration the controller will wait\nbefore terminating a node, measured from when the node is created. This\nis useful to implement features like eventually consistent node upgrade,\nmemory leak protection, and disruption testing.",
               "pattern": "^(([0-9]+(s|m|h))+)|(Never)$",
               "type": "string"
             }
@@ -73,7 +114,7 @@
           "type": "object"
         },
         "template": {
-          "description": "Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with. NodeClaims launched from this NodePool will often be further constrained than the template specifies.",
+          "description": "Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.\nNodeClaims launched from this NodePool will often be further constrained than the template specifies.",
           "properties": {
             "metadata": {
               "properties": {
@@ -81,7 +122,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
@@ -90,7 +131,7 @@
                     "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "maxProperties": 100,
                   "type": "object",
                   "x-kubernetes-validations": [
@@ -128,10 +169,10 @@
               "description": "NodeClaimSpec describes the desired state of the NodeClaim",
               "properties": {
                 "kubelet": {
-                  "description": "Kubelet defines args to be used when configuring kubelet on provisioned nodes. They are a subset of the upstream types, recognizing not all options may be supported. Wherever possible, the types and names should reflect the upstream kubelet types.",
+                  "description": "Kubelet defines args to be used when configuring kubelet on provisioned nodes.\nThey are a subset of the upstream types, recognizing not all options may be supported.\nWherever possible, the types and names should reflect the upstream kubelet types.",
                   "properties": {
                     "clusterDNS": {
-                      "description": "clusterDNS is a list of IP addresses for the cluster DNS server. Note that not all providers may use all addresses.",
+                      "description": "clusterDNS is a list of IP addresses for the cluster DNS server.\nNote that not all providers may use all addresses.",
                       "items": {
                         "type": "string"
                       },
@@ -156,7 +197,7 @@
                       ]
                     },
                     "evictionMaxPodGracePeriod": {
-                      "description": "EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in response to soft eviction thresholds being met.",
+                      "description": "EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in\nresponse to soft eviction thresholds being met.",
                       "format": "int32",
                       "type": "integer"
                     },
@@ -188,14 +229,14 @@
                       ]
                     },
                     "imageGCHighThresholdPercent": {
-                      "description": "ImageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive. When specified, the value must be greater than ImageGCLowThresholdPercent.",
+                      "description": "ImageGCHighThresholdPercent is the percent of disk usage after which image\ngarbage collection is always run. The percent is calculated by dividing this\nfield value by 100, so this field must be between 0 and 100, inclusive.\nWhen specified, the value must be greater than ImageGCLowThresholdPercent.",
                       "format": "int32",
                       "maximum": 100,
                       "minimum": 0,
                       "type": "integer"
                     },
                     "imageGCLowThresholdPercent": {
-                      "description": "ImageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The percent is calculated by dividing this field value by 100, so the field value must be between 0 and 100, inclusive. When specified, the value must be less than imageGCHighThresholdPercent",
+                      "description": "ImageGCLowThresholdPercent is the percent of disk usage before which image\ngarbage collection is never run. Lowest disk usage to garbage collect to.\nThe percent is calculated by dividing this field value by 100,\nso the field value must be between 0 and 100, inclusive.\nWhen specified, the value must be less than imageGCHighThresholdPercent",
                       "format": "int32",
                       "maximum": 100,
                       "minimum": 0,
@@ -228,13 +269,13 @@
                       ]
                     },
                     "maxPods": {
-                      "description": "MaxPods is an override for the maximum number of pods that can run on a worker node instance.",
+                      "description": "MaxPods is an override for the maximum number of pods that can run on\na worker node instance.",
                       "format": "int32",
                       "minimum": 0,
                       "type": "integer"
                     },
                     "podsPerCore": {
-                      "description": "PodsPerCore is an override for the number of pods that can run on a worker node instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if MaxPods is a lower value, that value will be used.",
+                      "description": "PodsPerCore is an override for the number of pods that can run on a worker node\ninstance based on the number of cpu cores. This value cannot exceed MaxPods, so, if\nMaxPods is a lower value, that value will be used.",
                       "format": "int32",
                       "minimum": 0,
                       "type": "integer"
@@ -308,7 +349,7 @@
                 "requirements": {
                   "description": "Requirements are layered with GetLabels and applied to every node.",
                   "items": {
-                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                     "properties": {
                       "key": {
                         "description": "The label key that the selector applies to.",
@@ -343,7 +384,7 @@
                         ]
                       },
                       "operator": {
-                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                        "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                         "enum": [
                           "In",
                           "NotIn",
@@ -355,7 +396,7 @@
                         "type": "string"
                       },
                       "values": {
-                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                        "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -405,15 +446,16 @@
                     }
                   },
                   "type": "object",
+                  "maxProperties": 0,
                   "additionalProperties": false
                 },
                 "startupTaints": {
-                  "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
+                  "description": "StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically\nwithin a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by\ndaemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning\npurposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.",
                   "items": {
-                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
                     "properties": {
                       "effect": {
-                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "description": "Required. The effect of the taint on pods\nthat do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute.",
                         "enum": [
                           "NoSchedule",
                           "PreferNoSchedule",
@@ -428,7 +470,7 @@
                         "type": "string"
                       },
                       "timeAdded": {
-                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "description": "TimeAdded represents the time at which the taint was added.\nIt is only written for NoExecute taints.",
                         "format": "date-time",
                         "type": "string"
                       },
@@ -450,10 +492,10 @@
                 "taints": {
                   "description": "Taints will be applied to the NodeClaim's node.",
                   "items": {
-                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "description": "The node this Taint is attached to has the \"effect\" on\nany pod that does not tolerate the Taint.",
                     "properties": {
                       "effect": {
-                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "description": "Required. The effect of the taint on pods\nthat do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute.",
                         "enum": [
                           "NoSchedule",
                           "PreferNoSchedule",
@@ -468,7 +510,7 @@
                         "type": "string"
                       },
                       "timeAdded": {
-                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "description": "TimeAdded represents the time at which the taint was added.\nIt is only written for NoExecute taints.",
                         "format": "date-time",
                         "type": "string"
                       },
@@ -500,7 +542,7 @@
           "additionalProperties": false
         },
         "weight": {
-          "description": "Weight is the priority given to the nodepool during scheduling. A higher numerical weight indicates that this nodepool will be ordered ahead of other nodepools with lower weights. A nodepool with no weight will be treated as if it is a nodepool with a weight of 0.",
+          "description": "Weight is the priority given to the nodepool during scheduling. A higher\nnumerical weight indicates that this nodepool will be ordered\nahead of other nodepools with lower weights. A nodepool with no weight\nwill be treated as if it is a nodepool with a weight of 0.",
           "format": "int32",
           "maximum": 100,
           "minimum": 1,


### PR DESCRIPTION
# TL:DR;
Updates CRDs-catalog for Karpenter 0.34.x configurations

## Issue
Karpenter has made some changes to their CRDs between versions 0.32.x & 0.33.x, deprecating the `v1alphax` APIs and replacing them with `v1beta1`. ([more details](https://karpenter.sh/v0.34/upgrading/upgrade-guide/#upgrading-to-v0320)) Karpenter deployments running release v0.32.x allow clusters to operate both alpha & beta APIs for safer onboarding updates of applications.

Starting in Karpenter 0.34.x, the `nodepool.spec.disruption.budgets` spec is introduced which the current CRDs-catalog has no references for. We've introduced those values to our configuration and hit this error when running validation for the beta APIs:
```
karpenter-nodepools.yaml - NodePool test-node-pool is invalid: problem validating schema.
Check JSON formatting: jsonschema: '/spec/disruption' does not validate with https://raw.githubusercontent.com/InfinityFlowApp/CRDs-catalog/main/karpenter.sh/nodepool_v1beta1.json#/properties/spec/properties/disruption/additionalProperties: additionalProperties 'budgets' not allowed
```

## Solution
I referenced the 0.33.5 & 0.34.6 CRDs published for the v1beta1 EC2NodeClass, NodeClaim and NodePool APIs and compared the configurations to one another. I also went back to 0.32.10 to ensure there were no major changes introduced there either. Finding the changes for `budgets` in the NodePools manifest, I found some other small changes that were also needed to make the configurations match. 

Now we can use my forked CRDs-catalog configuration and we get valid manifests produced and updated with the new values as expected:
```
kubeconform -schema-location default -schema-location 'https://raw.githubusercontent.com/NicholasRaymondiSpot/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' "$output_path/$chart_name.yaml"

Changes in karpenter-nodepools.yaml:
-    expireAfter: Never
+    expireAfter: 720h
+    budgets:
+      - nodes: "10%"
```

## Changes Made
* All three manifests have had their descriptions reformatted with newline character breaks.
* EC2NodeClass
** `instanceProfile` was added, it was missing since 0.32.x
** `instanceStorePolicy` is added with a default RAID0 enumeration
* NodePools
** Added `budgets` configuration with it's defaults
** Added `maxProperties: 0` to the `spec.template.requirements.resources`

## Notes
This was tested with Karpenter 0.34.6, there is no guarantee that these changes will work with newer releases of the addon. I'll be adding more changes soon for versions 0.35.x & 0.36x if they're needed.

## Resources & References
https://raw.githubusercontent.com/aws/karpenter/v0.32.10/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.33.5/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.34.6/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml

https://raw.githubusercontent.com/aws/karpenter/v0.32.10/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.33.5/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.34.6/pkg/apis/crds/karpenter.sh_nodeclaims.yaml

https://raw.githubusercontent.com/aws/karpenter/v0.32.10/pkg/apis/crds/karpenter.sh_nodepools.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.33.5/pkg/apis/crds/karpenter.sh_nodepools.yaml
https://raw.githubusercontent.com/aws/karpenter/v0.34.6/pkg/apis/crds/karpenter.sh_nodepools.yaml

[Upgrading to v0.34.0+](https://karpenter.sh/v0.34/upgrading/upgrade-guide/#upgrading-to-v0340)

## Related PRs
[chore: update karpenter crds to version v0.35.0 #280](https://github.com/datreeio/CRDs-catalog/pull/280)
[Updating Karpenter v1beta1 Spec #318](https://github.com/datreeio/CRDs-catalog/pull/318)